### PR TITLE
Bioschemas website restructure

### DIFF
--- a/Scripting-Tool/ConfigFile.ini
+++ b/Scripting-Tool/ConfigFile.ini
@@ -1,9 +1,10 @@
 [Github]
 url = https://github.com/BioSchemas/bioschemas.github.io/archive/master.zip
-currentProfilesDirectoryPath = /bioschemas.github.io-master/_specifications/
-currentTypesDirectoryPath = /bioschemas.github.io-master/_types/
-draftProfilesDirectoryPath = /bioschemas.github.io-master/_devSpecs/
-draftTypesDirectoryPath = /bioschemas.github.io-master/_devTypes/
+githubDirectoryPath = /bioschemas.github.io-master/
+currentProfilesDirectoryPath = _profiles/
+currentTypesDirectoryPath = _types/
+draftProfilesDirectoryPath = _devSpecs/
+draftTypesDirectoryPath = _devTypes/
 
 [Bioschemas]
 url = http://bio.sdo-bioschemas-227516.appspot.com/

--- a/Scripting-Tool/generateBioschemasFiles.py
+++ b/Scripting-Tool/generateBioschemasFiles.py
@@ -562,12 +562,23 @@ def createShExSchema(definitionObject, additionalTitleInfo):
     # Create the ShEx for a Bioschemas Profiles
     try:
         print("Creating ShEx for " + definitionObject["spec_info"]["title"])
+
+        # Metadata for the generate file
         shape = '# Auto generated shape definitions using ' + sys.argv[0] + '\n'
         shape += '# Date generated: ' + datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S") + '\n'
         shape += '# Profile: ' + definitionObject["spec_info"]["title"] + \
             ' (v' + str(definitionObject["spec_info"]["version"]) + ")" + \
             additionalTitleInfo + '\n\n'
-        shapeMinimum = '<' + definitionObject["spec_info"]["title"] + 'Minimum> {\n '
+
+        # Prefixes and utility shapes
+        shape += 'PREFIX schema: <http://schema.org/>\n'
+        shape += 'PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n'
+        shape += 'PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n'
+        shape += 'PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n'
+        shape += '\n<URL>\n\t xsd:string OR IRI\n'
+
+        # Minimum shape
+        shapeMinimum = '\n<' + definitionObject["spec_info"]["title"] + 'Minimum> {\n '
         shapeMinimum += '\trdf:type [' + definitionObject["spec_info"]["title"] + '] ;'
     except:
         print("Error: createShExSchema")

--- a/Scripting-Tool/generateBioschemasFiles.py
+++ b/Scripting-Tool/generateBioschemasFiles.py
@@ -84,6 +84,8 @@ def main(argv):
     global ListOfBioschemasProfiles
     global ListOfBioschemasTypes
 
+    #TODO: Tidy up! The code now processes all profiles in one pass
+
     # Retrieve configuration variables
     try:
         config = configparser.ConfigParser()
@@ -126,6 +128,9 @@ def main(argv):
     processJSONDictionary("/profiles/","/tables/", "")
 
     print("Processing Current Profiles Finished.")
+
+    #TODO: Use ProfileMetadata to copy release into profile directory and latest draft to draft-profile directory
+
 
     # # Process Draft Profiles
     # print("Processing Draft Profiles with the following relative paths:")

--- a/Scripting-Tool/generateBioschemasFiles.py
+++ b/Scripting-Tool/generateBioschemasFiles.py
@@ -224,13 +224,13 @@ def extractYAML():
         os.makedirs(TempWorkingDirectoryYAML)
 
     for profile in ProfileMetadata:
-        print("Processing: ", profile)
+        # print("Processing: ", profile)
         htmlToProcess = glob.glob(
             TempWorkingDirectory + GithubProfilePath + profile + "/*.html")
 
         for htmlFile in htmlToProcess:
             try:
-                print("\tFile: ",htmlFile)
+                # print("\tFile: ",htmlFile)
                 htmlFileName = os.path.basename(htmlFile)
                 profileName = profile + "_" + os.path.splitext(htmlFileName)[0]
                 newYAMLFile = TempWorkingDirectoryYAML + profileName + ".yaml"
@@ -438,7 +438,7 @@ def createJSONSchema(definitionObject, additionalTitleInfo):
         minimumSchemaObject["required"] = profileRequiredProperties
 
     except:
-        print("Error: createJSONSchema")
+        print("Error: createJSONSchema:", definitionObject["spec_info"]["title"], additionalTitleInfo)
 
     return schemaJSONObject, minimumSchemaObject
 
@@ -571,7 +571,7 @@ def generateBioschemasDefinition(definition):
         return definitionSchema
 
     except:
-        print("Error: generateBioschemasDefinition")
+        print("Error: generateBioschemasDefinition for", definition)
 
 
 def generateSchemaDefinition(definition):
@@ -650,7 +650,7 @@ def createJSONTable(definitionObject):
                 propertyObject["marginality"] = property["marginality"]
                 tableJSONObject[property["property"]] = propertyObject
     except:
-        print("Error: createJSONTable")
+        print("Error: createJSONTable:", definitionObject["spec_info"]["title"])
 
     return tableJSONObject
 
@@ -660,7 +660,6 @@ def addMinimumDefinitions(jsonSchemaDictionary,definitionsMinimum):
     print("Adding minimum versions of Bioschemas profiles to definitions for profiles:")
 
     for key, value in jsonSchemaDictionary.items():
-        print("Adding minimum version for:", key)
         try:
             for key2, value2 in jsonSchemaDictionary[key]["definitions"].items():
                 # Check if there is a Bioschemas Profile

--- a/Scripting-Tool/generateBioschemasFiles.py
+++ b/Scripting-Tool/generateBioschemasFiles.py
@@ -540,7 +540,7 @@ def generateBioschemasDefinition(definition):
 
                                 identifierObject = {}
                                 identifierObject["title"] = "Link to other resource"
-                                identifierObject["description"] = "Placeholder Description"
+                                identifierObject["description"] = "URL of page describing the resource"
                                 identifierObject["$ref"] = "#/definitions/URL"
                                 typeProperties["@id"] = identifierObject
 
@@ -592,7 +592,7 @@ def generateSchemaDefinition(definition):
 
     identifierObject = {}
     identifierObject["title"] = "Link to other resource"
-    identifierObject["description"] = "Placeholder Description"
+    identifierObject["description"] = "URL of page describing the resource"
     identifierObject["$ref"] = "#/definitions/URL"
     schemaProperties["@id"] = identifierObject
 

--- a/Scripting-Tool/generateBioschemasFiles.py
+++ b/Scripting-Tool/generateBioschemasFiles.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import sys
 import getopt
 import tempfile
@@ -567,7 +567,7 @@ def createJSONTable(definitionObject):
                 propertyObject["example"] = property["example"]
             if property["controlled_vocab"]:
                 propertyObject["controlled_vocab"] = property["controlled_vocab"]
-            
+
             # If Property has additional information add to JSON file output
             if propertyObject:
                 propertyObject["marginality"] = property["marginality"]

--- a/Scripting-Tool/generateBioschemasFiles.py
+++ b/Scripting-Tool/generateBioschemasFiles.py
@@ -135,6 +135,7 @@ def main(argv):
     ProfileJSONSchemaDictionary = {}
     ProfileJSONTableDictionary = {}
     ProfileMinimumDefinitionDictionary = {}
+    ProfileShExDictionary = {}
     ListOfBioschemasProfiles = []
     ListOfBioschemasTypes = []
 
@@ -234,6 +235,7 @@ def processJSONDictionary(profileDirectory, tableDirectory, additionalTitleInfo)
             fullSchema, minimumSchema =  createJSONSchema(value, additionalTitleInfo )
             ProfileJSONSchemaDictionary[key] = fullSchema
             ProfileMinimumDefinitionDictionary[key] = minimumSchema
+            ProfileShExDictionary[key] = createShExSchema(value, additionalTitleInfo)
             ProfileJSONTableDictionary[key + "-Table"] = createJSONTable(value)
         except:
             print("Error: processJSONDictionary")
@@ -555,6 +557,15 @@ def generateSchemaDefinition(definition):
 
     return schemaDefinition
 
+def createShExSchema(definitionObject, additionalTitleInfo):
+    # Create the ShEx for a Bioschemas Profiles
+    shexObject = {}
+    try:
+        print("Creating ShEx for " + definitionObject["spec_info"]["title"])
+    except:
+        print("Error: createShExSchema")
+
+    return shexObject
 
 def createJSONTable(definitionObject):
     # Create JSON object with additional information about property (example's and controlled vocabularies)

--- a/Scripting-Tool/generateBioschemasFiles.py
+++ b/Scripting-Tool/generateBioschemasFiles.py
@@ -15,6 +15,7 @@ from yaml import Loader
 # Global Variables set by properties file in main method
 GithubURL = ""
 GithubDirectoryPath = ""
+GithubProfilePath = ""
 GithubTypePath = ""
 BioschemasURL = ""
 SchemaURL = ""
@@ -70,6 +71,7 @@ propertyOrdering = {
 def main(argv):
     global GithubURL
     global GithubDirectoryPath
+    global GithubProfilePath
     global GithubTypePath
     global BioschemasURL
     global SchemaURL
@@ -88,10 +90,11 @@ def main(argv):
         config.read("ConfigFile.ini")
 
         GithubURL = config.get("Github","url")
-        CurrentProfilesDirectoryPath = config.get("Github","currentProfilesDirectoryPath")
-        CurrentTypesDirectoryPath = config.get("Github","currentTypesDirectoryPath")
-        DraftProfilesDirectoryPath = config.get("Github","draftProfilesDirectoryPath")
-        DraftTypesDirectoryPath = config.get("Github","draftTypesDirectoryPath")
+        GithubDirectoryPath = config.get("Github", "githubDirectoryPath")
+        CurrentProfilesDirectoryPath = GithubDirectoryPath + config.get("Github","currentProfilesDirectoryPath")
+        CurrentTypesDirectoryPath = GithubDirectoryPath + config.get("Github","currentTypesDirectoryPath")
+        DraftProfilesDirectoryPath = GithubDirectoryPath + config.get("Github","draftProfilesDirectoryPath")
+        DraftTypesDirectoryPath = GithubDirectoryPath + config.get("Github","draftTypesDirectoryPath")
         BioschemasURL = config.get("Bioschemas","url")
         SchemaURL = config.get("SchemaOrg","url")
 
@@ -100,54 +103,54 @@ def main(argv):
         print("Provide all arguments through ConfigFile.ini")
         sys.exit(2)
 
-    # Process Current Profiles
-    print("Processing Current Profiles with the following arguments:")
-    print("Github URL:", GithubURL)
-    print("Github Profiles Path: ", CurrentProfilesDirectoryPath)
-    GithubDirectoryPath = CurrentProfilesDirectoryPath
-    print("Github Types Path: ", CurrentTypesDirectoryPath)
-    GithubTypePath = CurrentTypesDirectoryPath
-    print("Bioschemas URL: ", BioschemasURL)
-    print("Schema.org URL: ", SchemaURL)
-
-    # Transformation Process for current profiles.
+    print("Retrieve GitHub repository with following arguments:")
+    print("\tGithub URL:", GithubURL)
+    print("\tGithub Directory:", GithubDirectoryPath)
+    print("\tBioschemas URL: ", BioschemasURL)
+    print("\tSchema.org URL: ", SchemaURL)
     downloadGithubRepository()
     extractGithubRepositoryZip()
+    extractProfileMetadata()
+    extractTypeMetadata()
+
+    # Process Current Profiles
+    print("Processing Current Profiles with the following relative paths:")
+    print("\tGithub Profiles Path: ", CurrentProfilesDirectoryPath)
+    GithubProfilePath = CurrentProfilesDirectoryPath
+    print("\tGithub Types Path: ", CurrentTypesDirectoryPath)
+    GithubTypePath = CurrentTypesDirectoryPath
+
+    # Transformation Process for current profiles.
     extractYAML()
     convertYAML()
     processJSONDictionary("/profiles/","/tables/", "")
 
     print("Processing Current Profiles Finished.")
 
-    # Process Draft Profiles
-    print("Processing Draft Profiles with the following arguments:")
-    print("Github URL:", GithubURL)
-    print("Github Profiles Path: ", DraftProfilesDirectoryPath)
-    GithubDirectoryPath = DraftProfilesDirectoryPath
-    print("Github Types Path: ", DraftTypesDirectoryPath)
-    GithubTypePath = DraftTypesDirectoryPath
-    print("Bioschemas URL: ", BioschemasURL)
-    print("Schema.org URL: ", SchemaURL)
-
-    # Reset global variables for draft profiles
-    TempWorkingDirectory = ""
-    TempWorkingDirectoryYAML = ""
-    ProfileJSONDefinitionDictionary = {}
-    ProfileJSONSchemaDictionary = {}
-    ProfileJSONTableDictionary = {}
-    ProfileMinimumDefinitionDictionary = {}
-    ProfileShExDictionary = {}
-    ListOfBioschemasProfiles = []
-    ListOfBioschemasTypes = []
-
-    # Transformation Process for Draft Profiles
-    downloadGithubRepository()
-    extractGithubRepositoryZip()
-    extractYAML()
-    convertYAML()
-    processJSONDictionary("/draft-profiles/","/draft-tables/", " Draft")
-
-    print("Processing Draft Profiles Finished.")
+    # # Process Draft Profiles
+    # print("Processing Draft Profiles with the following relative paths:")
+    # print("\tGithub Profiles Path: ", DraftProfilesDirectoryPath)
+    # GithubProfilePath = DraftProfilesDirectoryPath
+    # print("\tGithub Types Path: ", DraftTypesDirectoryPath)
+    # GithubTypePath = DraftTypesDirectoryPath
+    #
+    # # Reset global variables for draft profiles
+    # ##TempWorkingDirectory = ""
+    # ##TempWorkingDirectoryYAML = ""
+    # ProfileJSONDefinitionDictionary = {}
+    # ProfileJSONSchemaDictionary = {}
+    # ProfileJSONTableDictionary = {}
+    # ProfileMinimumDefinitionDictionary = {}
+    # ProfileShExDictionary = {}
+    # ListOfBioschemasProfiles = []
+    # ListOfBioschemasTypes = []
+    #
+    # # Transformation Process for Draft Profiles
+    # extractYAML()
+    # convertYAML()
+    # processJSONDictionary("/draft-profiles/","/draft-tables/", " Draft")
+    #
+    # print("Processing Draft Profiles Finished.")
 
 
 def downloadGithubRepository():
@@ -164,6 +167,7 @@ def downloadGithubRepository():
     except:
         print("Error: downloadGithubRepository")
         sys.exit(2)
+    print("GitHub repository zip file downloaded")
 
 
 def extractGithubRepositoryZip():
@@ -174,7 +178,35 @@ def extractGithubRepositoryZip():
     except:
         print("Error: extractGithubRepositoryZip")
         sys.exit(2)
+    print("GitHub zip file extracted")
 
+def extractProfileMetadata():
+    # Extract the Bioschemas profiles metadata
+    global ProfileMetadata
+    yamlDataFile = TempWorkingDirectory + GithubDirectoryPath + "_data/profile_versions.yaml"
+    print("Profile data file:", yamlDataFile)
+    try:
+        with open(yamlDataFile, "r", encoding="utf8") as input:
+            ProfileMetadata = list(yaml.load_all(input, Loader=Loader))[0]
+        ListOfBioschemasProfiles.extend(list(ProfileMetadata.keys()))
+    except:
+        print("ERROR: extractProfileMetadata")
+        sys.exit(2)
+    print("Finished extracting profile metadata")
+
+def extractTypeMetadata():
+    # Extract the Bioschemas types metadata
+    global BioschemasTypeMetadata
+    yamlDataFile = TempWorkingDirectory + GithubDirectoryPath + "_data/type_versions.yaml"
+    print("Type data file:", yamlDataFile)
+    try:
+        with open(yamlDataFile, "r", encoding="utf8") as input:
+            BioschemasTypeMetadata = list(yaml.load_all(input, Loader=Loader))[0]
+        ListOfBioschemasTypes.extend(list(BioschemasTypeMetadata.keys()))
+    except:
+        print("ERROR: extractTypeMetadata")
+        sys.exit(2)
+    print("Finished extracting type metadata")
 
 def extractYAML():
     # Extract the YAML from the HTML files by specifiying the directory in the command line arguments using -d
@@ -186,25 +218,29 @@ def extractYAML():
     if not os.path.exists(TempWorkingDirectoryYAML):
         os.makedirs(TempWorkingDirectoryYAML)
 
-    htmlToProcess = glob.glob(
-        TempWorkingDirectory + GithubDirectoryPath + "*.html")
+    for profile in ProfileMetadata:
+        print("Processing: ", profile)
+        htmlToProcess = glob.glob(
+            TempWorkingDirectory + GithubProfilePath + profile + "/*.html")
 
-    for htmlFile in htmlToProcess:
-        try:
-            htmlFileName = os.path.basename(htmlFile)
-            profileName = os.path.splitext(htmlFileName)[0]
-            newYAMLFile = TempWorkingDirectoryYAML + profileName + ".yaml"
-            with open(htmlFile, "r", encoding="utf8") as input:
-                with open(newYAMLFile, "w", encoding="utf8") as output:
-                    seperatorCount = 0
-                    for line in input:
-                        if "---" == line.strip():
-                            seperatorCount = seperatorCount + 1
-                            if seperatorCount == 2:
-                                break
-                        output.write(line)
-        except:
-            print("Error: extractYAML")
+        for htmlFile in htmlToProcess:
+            try:
+                print("\tFile: ",htmlFile)
+                htmlFileName = os.path.basename(htmlFile)
+                profileName = profile + "_" + os.path.splitext(htmlFileName)[0]
+                newYAMLFile = TempWorkingDirectoryYAML + profileName + ".yaml"
+                with open(htmlFile, "r", encoding="utf8") as input:
+                    with open(newYAMLFile, "w", encoding="utf8") as output:
+                        seperatorCount = 0
+                        for line in input:
+                            if "---" == line.strip():
+                                seperatorCount = seperatorCount + 1
+                                if seperatorCount == 2:
+                                    break
+                            output.write(line)
+            except:
+                print("Error: extractYAML")
+    print("YAML successfully extracted")
 
 
 def convertYAML():
@@ -212,8 +248,8 @@ def convertYAML():
     global ProfileJSONDefinitionDictionary
 
     yamlToProcess = glob.glob(TempWorkingDirectoryYAML + "*.yaml")
-
     for yamlFile in yamlToProcess:
+        # print("\tProcessing: ", yamlFile)
         try:
             yamlFileName = os.path.basename(yamlFile)
             profileName = os.path.splitext(yamlFileName)[0]
@@ -222,21 +258,26 @@ def convertYAML():
                     input, Loader=Loader)
         except:
             print("Error: convertYAML")
+    print("YAML successfully converted to JSON")
 
 
 def processJSONDictionary(profileDirectory, tableDirectory, additionalTitleInfo):
-    # Get List of Profiles and List of Types for Bioschemas
-    listOfBioschemasProfiles()
-    listOfBioschemasTypes()
+    # Check List of Profiles and List of Types for Bioschemas is not empty
+    if not ListOfBioschemasProfiles:
+        print("ERROR: No profiles retrieved")
+        return
+    if not ListOfBioschemasTypes:
+        print("ERROR: No types retrieved")
+        return
 
     # For each definition create a JSON-Schema and JSON Table file
     for key, value in ProfileJSONDefinitionDictionary.items():
         try:
-            print(key)
+            print("\t", key)
             fullSchema, minimumSchema =  createJSONSchema(value, additionalTitleInfo )
             ProfileJSONSchemaDictionary[key] = fullSchema
             ProfileMinimumDefinitionDictionary[key] = minimumSchema
-            ProfileShExDictionary[key] = createShExSchema(value, additionalTitleInfo)
+            # ProfileShExDictionary[key] = createShExSchema(value, additionalTitleInfo)
             ProfileJSONTableDictionary[key + "-Table"] = createJSONTable(value)
         except:
             print("Error: processJSONDictionary")
@@ -304,7 +345,7 @@ def createJSONSchema(definitionObject, additionalTitleInfo):
 
         # dct:conformsTo
         dctObject = {}
-        dctObject["default"] = "https://bioschemas.org/specifications/" + \
+        dctObject["default"] = "https://bioschemas.org/profiles/" + \
             definitionObject["spec_info"]["title"] + "/" + \
             str(definitionObject["spec_info"]["version"])
         dctObject["options"] = optionsObject
@@ -579,7 +620,8 @@ def createShExSchema(definitionObject, additionalTitleInfo):
 
         # Minimum shape
         shapeMinimum = '\n<' + definitionObject["spec_info"]["title"] + 'Minimum> {\n '
-        shapeMinimum += '\trdf:type [schema:' + definitionObject["spec_info"]["title"] + '] ;'
+        shapeMinimum += '\trdf:type [schema:' + definitionObject["spec_info"]["title"] + '] ;\n'
+        shapeMinimum += '\tdct:conformsTo IRI ;'
     except:
         print("Error: createShExSchema")
     shape += shapeMinimum + '\n}\n\n'
@@ -613,39 +655,23 @@ def addMinimumDefinitions(jsonSchemaDictionary,definitionsMinimum):
     print("Adding minimum versions of Bioschemas profiles to definitions for profiles:")
 
     for key, value in jsonSchemaDictionary.items():
+        print("Adding minimum version for:", key)
         try:
             for key2, value2 in jsonSchemaDictionary[key]["definitions"].items():
-                if key2 in definitionsMinimum:
-                    jsonSchemaDictionary[key]["definitions"][key2] = definitionsMinimum[key2]
+                # Check if there is a Bioschemas Profile
+                if key2 in ListOfBioschemasProfiles:
+                    # Retrieve latest stable release
+                    latest_release = ProfileMetadata[key2]["latest_release"]
+                    if latest_release is None:
+                        # No latest stable release, use latest draft instead
+                        latest_publication = ProfileMetadata[key2]["latest_publication"]
+                        jsonSchemaDictionary[key]["definitions"][key2] = definitionsMinimum[key2+"_"+latest_publication]
+                    else:
+                        jsonSchemaDictionary[key]["definitions"][key2] = definitionsMinimum[key2+"_"+latest_release]
         except:
             print("Error: addMinimumDefinitions for profile: ", key)
 
     return jsonSchemaDictionary
-
-def listOfBioschemasProfiles():
-    # Retrieve a list of all Bioschemas profiles
-    global ListOfBioschemasProfiles
-    bioschemasProfilesDirectory = TempWorkingDirectory + GithubDirectoryPath
-    tempListOfProfiles = glob.glob(bioschemasProfilesDirectory + "*.html")
-
-    for profile in tempListOfProfiles:
-        htmlFileName = os.path.basename(profile)
-        profileName = os.path.splitext(htmlFileName)[0]
-        ListOfBioschemasProfiles.append(profileName)
-
-
-def listOfBioschemasTypes():
-    # Retrieve a list of all Bioschemas types
-    global ListOfBioschemasTypes
-
-    bioschemasTypesDirectory = TempWorkingDirectory + GithubTypePath
-    tempListOfTypes = glob.glob(bioschemasTypesDirectory + "*.html")
-
-    for type in tempListOfTypes:
-        htmlFileName = os.path.basename(type)
-        typeName = os.path.splitext(htmlFileName)[0]
-        ListOfBioschemasTypes.append(typeName)
-
 
 def fetchSchemaDescription(definition):
     # Fetch the description of Schema.org types

--- a/Scripting-Tool/generateBioschemasFiles.py
+++ b/Scripting-Tool/generateBioschemasFiles.py
@@ -146,7 +146,6 @@ def main(argv):
     # ProfileJSONSchemaDictionary = {}
     # ProfileJSONTableDictionary = {}
     # ProfileMinimumDefinitionDictionary = {}
-    # ProfileShExDictionary = {}
     # ListOfBioschemasProfiles = []
     # ListOfBioschemasTypes = []
     #
@@ -282,7 +281,6 @@ def processJSONDictionary(profileDirectory, tableDirectory, additionalTitleInfo)
             fullSchema, minimumSchema =  createJSONSchema(value, additionalTitleInfo )
             ProfileJSONSchemaDictionary[key] = fullSchema
             ProfileMinimumDefinitionDictionary[key] = minimumSchema
-            # ProfileShExDictionary[key] = createShExSchema(value, additionalTitleInfo)
             ProfileJSONTableDictionary[key + "-Table"] = createJSONTable(value)
         except:
             print("Error: processJSONDictionary")
@@ -603,35 +601,6 @@ def generateSchemaDefinition(definition):
     schemaDefinition["required"] = ["@id", "@type"]
 
     return schemaDefinition
-
-def createShExSchema(definitionObject, additionalTitleInfo):
-    # Create the ShEx for a Bioschemas Profiles
-    try:
-        print("Creating ShEx for " + definitionObject["spec_info"]["title"])
-
-        # Metadata for the generate file
-        shape = '# Auto generated shape definitions using ' + sys.argv[0] + '\n'
-        shape += '# Date generated: ' + datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S") + '\n'
-        shape += '# Profile: ' + definitionObject["spec_info"]["title"] + \
-            ' (v' + str(definitionObject["spec_info"]["version"]) + ")" + \
-            additionalTitleInfo + '\n\n'
-
-        # Prefixes and utility shapes
-        shape += 'PREFIX schema: <http://schema.org/>\n'
-        shape += 'PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n'
-        shape += 'PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n'
-        shape += 'PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n'
-        shape += '\n<URL>\n\t xsd:string OR IRI\n'
-
-        # Minimum shape
-        shapeMinimum = '\n<' + definitionObject["spec_info"]["title"] + 'Minimum> {\n '
-        shapeMinimum += '\trdf:type [schema:' + definitionObject["spec_info"]["title"] + '] ;\n'
-        shapeMinimum += '\tdct:conformsTo IRI ;'
-    except:
-        print("Error: createShExSchema")
-    shape += shapeMinimum + '\n}\n\n'
-    print(shape)
-    return shapeMinimum
 
 def createJSONTable(definitionObject):
     # Create JSON object with additional information about property (example's and controlled vocabularies)

--- a/Scripting-Tool/generateBioschemasFiles.py
+++ b/Scripting-Tool/generateBioschemasFiles.py
@@ -595,6 +595,14 @@ def generatePlaceholderDefinition(definition):
         schemaProperties["@type"] = typeObject
         requiredProperties.append("@type")
 
+        # Identifier (@id) link to other resource
+        identifierObject = {}
+        identifierObject["title"] = "Link to other resource"
+        identifierObject["description"] = "URL of page describing the resource"
+        identifierObject["$ref"] = "#/definitions/URL"
+        schemaProperties["@id"] = identifierObject
+        requiredProperties.append("@id")
+
         # Add properties and required sections to JSON Schema
         definitionSchema["properties"] = schemaProperties
         definitionSchema["required"] = requiredProperties

--- a/Scripting-Tool/generateBioschemasFiles.py
+++ b/Scripting-Tool/generateBioschemasFiles.py
@@ -579,7 +579,7 @@ def createShExSchema(definitionObject, additionalTitleInfo):
 
         # Minimum shape
         shapeMinimum = '\n<' + definitionObject["spec_info"]["title"] + 'Minimum> {\n '
-        shapeMinimum += '\trdf:type [' + definitionObject["spec_info"]["title"] + '] ;'
+        shapeMinimum += '\trdf:type [schema:' + definitionObject["spec_info"]["title"] + '] ;'
     except:
         print("Error: createShExSchema")
     shape += shapeMinimum + '\n}\n\n'

--- a/Scripting-Tool/generateBioschemasFiles.py
+++ b/Scripting-Tool/generateBioschemasFiles.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import sys
+import datetime
 import getopt
 import tempfile
 import requests
@@ -559,13 +560,20 @@ def generateSchemaDefinition(definition):
 
 def createShExSchema(definitionObject, additionalTitleInfo):
     # Create the ShEx for a Bioschemas Profiles
-    shexObject = {}
     try:
         print("Creating ShEx for " + definitionObject["spec_info"]["title"])
+        shape = '# Auto generated shape definitions using ' + sys.argv[0] + '\n'
+        shape += '# Date generated: ' + datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S") + '\n'
+        shape += '# Profile: ' + definitionObject["spec_info"]["title"] + \
+            ' (v' + str(definitionObject["spec_info"]["version"]) + ")" + \
+            additionalTitleInfo + '\n\n'
+        shapeMinimum = '<' + definitionObject["spec_info"]["title"] + 'Minimum> {\n '
+        shapeMinimum += '\trdf:type [' + definitionObject["spec_info"]["title"] + '] ;'
     except:
         print("Error: createShExSchema")
-
-    return shexObject
+    shape += shapeMinimum + '\n}\n\n'
+    print(shape)
+    return shapeMinimum
 
 def createJSONTable(definitionObject):
     # Create JSON object with additional information about property (example's and controlled vocabularies)

--- a/Scripting-Tool/generateBioschemasFiles.py
+++ b/Scripting-Tool/generateBioschemasFiles.py
@@ -570,7 +570,39 @@ def generateBioschemasDefinition(definition):
 
     except:
         print("Error: generateBioschemasDefinition for", definition)
+        definitionSchema = generatePlaceholderDefinition(definition)
+        return definitionSchema
 
+def generatePlaceholderDefinition(definition):
+    print("Generate place holder definition for", definition)
+
+    try:
+
+        definitionSchema = {}
+        schemaProperties = {}
+        requiredProperties = []
+        optionsObject = {}
+        optionsObject["hidden"] = "true"
+
+        # Title of Bioschemas Type
+        definitionSchema["title"] = definition
+
+        # JSON-LD Type Attribute
+        typeObject = {}
+        typeObject["default"] = definition
+        typeObject["options"] = optionsObject
+        typeObject["type"] = "string"
+        schemaProperties["@type"] = typeObject
+        requiredProperties.append("@type")
+
+        # Add properties and required sections to JSON Schema
+        definitionSchema["properties"] = schemaProperties
+        definitionSchema["required"] = requiredProperties
+
+        return definitionSchema
+    except:
+        print("Error: generatePlaceholderDefinition for", definition)
+        print(sys.exc_info()[0])
 
 def generateSchemaDefinition(definition):
     # Generate definition for Schema.org type

--- a/Web-Application/libs/bioschemas/setup.js
+++ b/Web-Application/libs/bioschemas/setup.js
@@ -1,7 +1,7 @@
 //GLOBAL VARIABLES
 var editor;
 var dropdownArray = new Array();
-var websiteURL = "http://www2.macs.hw.ac.uk/~st24/Web-Application/"
+var websiteURL = "https://www.macs.hw.ac.uk/SWeL/BioschemasGenerator"
 //JSON Editor Settings
 JSONEditor.defaults.theme = 'bootstrap4';
 JSONEditor.defaults.options["display_required_only"] = true;


### PR DESCRIPTION
Updated the Python generation script so that it works with the new* structure of the Bioschemas website. 

The generation script reads and generates for all the profiles. These get written to a single directory. 

At the moment we'll need to manually deploy and choose which schemas are "release" and which are "draft". I've created #11 to enhance this.

* when I say new, I mean the restructuring that was done in late 2019